### PR TITLE
Actually use sse_norm in benchmark

### DIFF
--- a/vectors_soa/benches/benchmarks.rs
+++ b/vectors_soa/benches/benchmarks.rs
@@ -95,7 +95,7 @@ fn benchmark(c: &mut Criterion) {
 
     let mut entities = prepare_entities_soa();
     c.bench_function("sse norm", move |b| {
-        b.iter(|| norm(&mut entities))
+        b.iter(|| sse_norm(&mut entities))
     });
 
     let mut entities = prepare_entities_soa();


### PR DESCRIPTION
The `sse_norm` benchmark is currently calling the scalar `norm` function. The correct function is called in the master branch, so this only applies to the pre-filled-in branch.